### PR TITLE
Correctly handle the last bit for the stone plane hex strings

### DIFF
--- a/leela_zero_pytorch/test_dataset.py
+++ b/leela_zero_pytorch/test_dataset.py
@@ -17,28 +17,41 @@ from leela_zero_pytorch.dataset import move_plane, stone_plane, Dataset, hex_to_
         ),
         (
             # upper left corner
-            hex_to_ndarray(hex(int('1000000000000000000' + '0000000000000000000' * 18, 2))[2:].zfill(91)),
+            hex_to_ndarray(
+                (hex(int('1000000000000000000' +
+                         '0000000000000000000' * 17 +
+                         '000000000000000000', 2)) + '0')[2:].zfill(91)),
             torch.tensor([1] + [0] * 360).float().view(19, 19),
         ),
         (
             # upper right corner
-            hex_to_ndarray(hex(int('0000000000000000001' + '0000000000000000000' * 18, 2))[2:].zfill(91)),
+            hex_to_ndarray(
+                (hex(int('0000000000000000001' +
+                         '0000000000000000000' * 17 +
+                         '000000000000000000', 2)) + '0')[2:].zfill(91)),
             torch.tensor([0] * 18 + [1] + [0] * 342).float().view(19, 19),
         ),
         (
             # bottom left corner
-            hex_to_ndarray(hex(int('0000000000000000000' * 18 + '1000000000000000000', 2))[2:].zfill(91)),
+            hex_to_ndarray(
+                (hex(int('0000000000000000000' * 18 +
+                         '100000000000000000', 2)) + '0')[2:].zfill(91)),
             torch.tensor([0] * 342 + [1] + [0] * 18).float().view(19, 19),
         ),
         (
             # bottom right corner
-            hex_to_ndarray(hex(int('0000000000000000000' * 18 + '0000000000000000001', 2))[2:].zfill(91)),
+            hex_to_ndarray(
+                (hex(int('0000000000000000000' * 18 +
+                         '000000000000000000', 2)) + '1')[2:].zfill(91)),
             torch.tensor([0] * 360 + [1]).float().view(19, 19),
         ),
         (
             # middle
-            hex_to_ndarray(hex(int(
-                '0000000000000000000' * 9 + '0000000001000000000' + '0000000000000000000' * 9, 2))[2:].zfill(91)),
+            hex_to_ndarray(
+                (hex(int('0000000000000000000' * 9 +
+                         '0000000001000000000' +
+                         '0000000000000000000' * 8 +
+                         '000000000000000000', 2)) + '0')[2:].zfill(91)),
             torch.tensor([0] * 180 + [1] + [0] * 180).float().view(19, 19),
         ),
     )


### PR DESCRIPTION
Fixes #3 

For a board with an odd number of rows and columns,
there are a total of (2*k+1)^2 = 4*k^2 + 4*k + 1 positions or "bits"
If we write this out as a hexadecimal, i.e. group by 4 bits (2^4 = 16),
there will always be 1 bit left, i.e. (4*k^2 + 4*k + 1) % 4 = 1.

LeelaZero handles this in a unique way:
Instead of treating the bit array as one hexadecimal (by prepending it with 0s to make the length divisible by 4),
it just appends the last bit at the end as 0 or 1. So we first need to parse the hex string without the last
digit, then append a bit to the parsed bit array at the end.

More details in the code below:
https://github.com/leela-zero/leela-zero/blob/b259e50d5cce34a12176846534f369ef5ffcebc1/src/Training.cpp\#L260-L264